### PR TITLE
Save memory when processing huge inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,10 @@ export class StdinLineStream {
   async getLine(): Promise<string> {
     return new Promise((resolve, reject) => {
       if (this.buffer.length > 0) {
+        this.rl.pause();
         resolve(this.buffer.shift());
       } else {
+        this.rl.resume();
         this.resolvers.push(resolve);
       }
     });


### PR DESCRIPTION
This tiny improvement ensures there's no memory issues in case a huge file is used as input:

```
node index.js < huge_file.txt
```